### PR TITLE
save address during account creation, more color contrast in date headers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ COPY --from=deps /myapp/node_modules /myapp/node_modules
 ADD prisma .
 RUN npx prisma generate
 
-ENV DATABASE_URL=file:/data/data.db
-RUN npx prisma db push
 ADD . .
 
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ COPY --from=deps /myapp/node_modules /myapp/node_modules
 
 ADD prisma .
 RUN npx prisma generate
+
+ENV DATABASE_URL=file:/data/data.db
 RUN npx prisma db push
 ADD . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ COPY --from=deps /myapp/node_modules /myapp/node_modules
 
 ADD prisma .
 RUN npx prisma generate
-
+RUN npx prisma db push
 ADD . .
 
 RUN npm run build

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -16,12 +16,9 @@ export async function getUserByStytchId(stytchId: User["stytchId"]) {
   return prisma.user.findUnique({ where: { stytchId } });
 }
 
-export async function createUser(email: User["email"], stytchId: string) {
+export async function createUser({ email, stytchId, address }: { email: User["email"]; stytchId: string; address: string }) {
   return prisma.user.create({
-    data: {
-      email,
-      stytchId,
-    },
+    data: { email, stytchId, address },
   });
 }
 

--- a/app/routes/start.tsx
+++ b/app/routes/start.tsx
@@ -39,6 +39,7 @@ export const action = async ({ request }: ActionFunctionArgs) => {
 
   const formData = await request.formData();
   const email = formData.get("email");
+  const address = formData.get("street-address");
   const rawCoordinates = formData.get("coordinates") as string;
   const baseUrl = formData.get("baseUrl") as string;
 
@@ -61,7 +62,12 @@ export const action = async ({ request }: ActionFunctionArgs) => {
     return redirect("/magic");
   }
 
-  if (typeof rawCoordinates !== "string" || rawCoordinates.length === 0) {
+  if (
+    typeof address !== "string" ||
+    address.length === 0 ||
+    typeof rawCoordinates !== "string" ||
+    rawCoordinates.length === 0
+  ) {
     return json(
       {
         errors: {
@@ -89,7 +95,9 @@ export const action = async ({ request }: ActionFunctionArgs) => {
   }
 
   const response = await callStytch(email, baseUrl);
-  if (response.user_id) await createUser(email, response.user_id);
+  if (response.user_id) {
+    await createUser({ email, stytchId: response.user_id, address });
+  }
 
   return redirect("/magic");
 };

--- a/app/styles.css
+++ b/app/styles.css
@@ -3,6 +3,7 @@
   --light: #ffffff;
   --mid-light: #eaeaea;
   --dark: #272c37;
+  --mid-dark: #57585b;
   --mid: #6e6a6f;
   --light-pickleball: #b5f1ff;
   --base-pickleball: #14cdf9;
@@ -213,7 +214,7 @@ body {
 }
 
 .nav_link {
-  color: var(--dim-text);
+  color: var(--mid-dark);
   position: relative;
 }
 

--- a/cypress/support/create-user.ts
+++ b/cypress/support/create-user.ts
@@ -21,7 +21,7 @@ async function createAndLogin(email: string) {
     throw new Error("All test emails must end in @example.com");
   }
 
-  const user = await createUser(email, uuid());
+  const user = await createUser({ email, stytchId: uuid(), address: 'fake' });
 
   const response = await createUserSession({
     request: new Request("test://test"),

--- a/prisma/migrations/20240619191142_add_address_column/migration.sql
+++ b/prisma/migrations/20240619191142_add_address_column/migration.sql
@@ -1,0 +1,17 @@
+-- RedefineTables
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "stytchId" TEXT NOT NULL,
+    "address" TEXT NOT NULL DEFAULT 'none',
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+INSERT INTO "new_User" ("createdAt", "email", "id", "stytchId", "updatedAt") SELECT "createdAt", "email", "id", "stytchId", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+CREATE UNIQUE INDEX "User_stytchId_key" ON "User"("stytchId");
+PRAGMA foreign_key_check;
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,7 @@ model User {
   id           String        @id @default(cuid())
   email        String        @unique
   stytchId     String        @unique
+  address      String        @default("none")
   createdAt    DateTime      @default(now())
   updatedAt    DateTime      @updatedAt
   reservations Reservation[]


### PR DESCRIPTION
fly.io didn't run the new migration in this PR automatically, even after adding the lines below to the Dockerfile.

```bash
ENV DATABASE_URL=file:/data/data.db
RUN npx prisma db push
```
i had to ssh into the box and run this:
```sql
ALTER TABLE User ADD COLUMN address text NOT NULL default 'none';
```
🙃 