### PR TITLE
invert taken colors, increase contrast and add dashed border

### DIFF
--- a/app/styles.css
+++ b/app/styles.css
@@ -350,34 +350,38 @@ body {
   cursor: not-allowed;
 }
 
-.schedule_content___pickleball .schedule_button.schedule_button___private {
+.schedule_content___pickleball .schedule_button.schedule_button___open {
   background-color: var(--light-pickleball);
-  color: var(--dark-pickleball);
+  border: 2px var(--dark-pickleball) dashed;
 }
 
-.schedule_content___pickleball .schedule_button.schedule_button___open {
+.schedule_content___pickleball .schedule_button.schedule_button___private {
   background-color: var(--dark-pickleball);
   color: var(--light-pickleball);
 }
 
-.schedule_content___tennis .schedule_button.schedule_button___private {
+.schedule_content___tennis .schedule_button.schedule_button___open {
   background-color: var(--light-tennis);
-  color: var(--dark-tennis);
+  border: 2px var(--dark-tennis) dashed;
 }
 
-.schedule_content___tennis .schedule_button.schedule_button___open {
+.schedule_content___tennis .schedule_button.schedule_button___private {
   background-color: var(--dark-tennis);
   color: var(--light-tennis);
 }
 
-.schedule_content___basketball .schedule_button.schedule_button___private {
+.schedule_content___basketball .schedule_button.schedule_button___open {
   background-color: var(--light-basketball);
-  color: var(--dark-basketball);
+  border: 2px var(--dark-basketball) dashed;
 }
 
-.schedule_content___basketball .schedule_button.schedule_button___open {
+.schedule_content___basketball .schedule_button.schedule_button___private {
   background-color: var(--dark-basketball);
   color: var(--light-basketball);
+}
+
+.schedule_button.schedule_button___open {
+  color: #000;
 }
 
 .schedule_content___pickleball .schedule_button.schedule_button___private:hover,


### PR DESCRIPTION
lighthouse let me know that there isn't quite enough contrast between the light backgrounds and the text.

before: (reserved)
<img width="387" alt="Screenshot 2024-06-25 at 9 05 48 PM" src="https://github.com/jgravois/court-dibs/assets/3011734/2a5b1286-6221-49b2-91f5-618ac4bafa49">

after: (open play)
<img width="352" alt="Screenshot 2024-06-25 at 9 06 37 PM" src="https://github.com/jgravois/court-dibs/assets/3011734/5f781dfe-b8c5-4fff-bd18-3f6a3a0a66b9">

i still don't think the styles make clear that there are two reservation types and what the difference between them is, but this is a little better.