### PR TITLE
validate stytch tokens intermittently

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,24 +1,16 @@
 import type { User } from "@prisma/client";
-import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
+import type { MetaFunction } from "@remix-run/node";
 import { json, useLoaderData } from "@remix-run/react";
 
 import { getReservations } from "~/models/reservation.server";
 import { Header } from "~/routes/header";
 import { ReservationList, Rez } from "~/routes/reservation-list";
-import { getSession } from "~/session.server";
 import { useOptionalUser } from "~/utils";
 
 export const meta: MetaFunction = () => [{ title: "Court dibs" }];
 
-export const loader = async ({ request }: LoaderFunctionArgs) => {
+export const loader = async () => {
   const reservations = await getReservations();
-
-  // next step is to verify that the token in the cookie is still valid
-  // with stytch when the application loads with stored credentials
-  const session = await getSession(request);
-  const token = session.get("stytch_session");
-  // confirmation that we can stash an arbitrary value and retrieve it.
-  token;
 
   return json({ reservations });
 };

--- a/app/routes/start.tsx
+++ b/app/routes/start.tsx
@@ -7,7 +7,7 @@ import invariant from "tiny-invariant";
 
 import { createUser, getUserByEmail } from "~/models/user.server";
 import { Header } from "~/routes/header";
-import { STYTCH_URL_BASE, validateCoordinates, validateEmail } from "~/utils";
+import { STYTCH_BASE, validateCoordinates, validateEmail } from "~/utils";
 
 const HALF = "AIzaSyBI_vhCo";
 const OTHER_HALF = "hiRS0dvt5Yk7sAJ-978T_mUwd8";
@@ -15,17 +15,20 @@ const OTHER_HALF = "hiRS0dvt5Yk7sAJ-978T_mUwd8";
 const ADDRESS_REQUIRED = "Street address is required";
 
 const callStytch = async (email: string) => {
-  const rawResponse = await fetch(STYTCH_URL_BASE + "/email/login_or_create", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Basic ${btoa(
-        `${process.env.STYTCH_PROJECT_ID}:${process.env.STYTCH_SECRET}`,
-      )}`,
-    },
+  const rawResponse = await fetch(
+    STYTCH_BASE + "/magic_links/email/login_or_create",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${btoa(
+          `${process.env.STYTCH_PROJECT_ID}:${process.env.STYTCH_SECRET}`,
+        )}`,
+      },
 
-    body: JSON.stringify({ email }),
-  });
+      body: JSON.stringify({ email }),
+    },
+  );
   return rawResponse.json();
 };
 

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -3,6 +3,7 @@ import invariant from "tiny-invariant";
 
 import type { User } from "~/models/user.server";
 import { getUserById } from "~/models/user.server";
+import { STYTCH_BASE } from "~/utils";
 
 invariant(process.env.SESSION_SECRET, "SESSION_SECRET must be set");
 
@@ -49,9 +50,43 @@ export async function requireUserId(
   const userId = await getUserId(request);
   if (!userId) {
     const searchParams = new URLSearchParams([["redirectTo", redirectTo]]);
-    throw redirect(`/login?${searchParams}`);
+    throw redirect(`/start?${searchParams}`);
   }
   return userId;
+}
+
+export async function requireValidStytchToken(
+  request: Request
+) {
+  const session = await getSession(request);
+  const session_token = session.get("stytch_session");
+  const lastValidated = session.get('last_validated')
+
+  const stale = new Date().valueOf() - lastValidated > 1000 * 60 * 60 * 12
+  if (!stale) return lastValidated
+
+  const rawResponse = await fetch(
+    STYTCH_BASE + "/sessions/authenticate",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${btoa(
+          `${process.env.STYTCH_PROJECT_ID}:${process.env.STYTCH_SECRET}`,
+        )}`,
+      },
+
+      body: JSON.stringify({
+        session_token,
+        session_duration_minutes: 43200
+      }),
+    },
+  );
+  const parsed = await rawResponse.json();
+  if (parsed.status_code !== 200) {
+    throw await logout(request)
+  }
+  return new Date().valueOf()
 }
 
 export async function requireUser(request: Request) {
@@ -69,23 +104,26 @@ export async function createUserSession({
   remember,
   redirectTo,
   token,
+  lastValidated,
 }: {
   request: Request;
   userId: string;
   remember: boolean;
   redirectTo: string;
   token?: string;
+  lastValidated?: number;
 }) {
   const session = await getSession(request);
   session.set(USER_SESSION_KEY, userId);
 
   if (token) session.set("stytch_session", token);
+  if (lastValidated) session.set("last_validated", lastValidated);
 
   return redirect(redirectTo, {
     headers: {
       "Set-Cookie": await sessionStorage.commitSession(session, {
         maxAge: remember
-          ? 60 * 60 * 24 * 7 // 7 days
+          ? 60 * 60 * 24 * 30 // 30 days
           : undefined,
       }),
     },
@@ -94,6 +132,23 @@ export async function createUserSession({
 
 export async function logout(request: Request) {
   const session = await getSession(request);
+  const session_token = session.get("stytch_session");
+
+  // invalidate token
+  await fetch(
+    STYTCH_BASE + "/sessions/revoke",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Basic ${btoa(
+          `${process.env.STYTCH_PROJECT_ID}:${process.env.STYTCH_SECRET}`,
+        )}`,
+      },
+      body: JSON.stringify({ session_token }),
+    },
+  );
+
   return redirect("/", {
     headers: {
       "Set-Cookie": await sessionStorage.destroySession(session),

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -9,10 +9,8 @@ import type { User } from "~/models/user.server";
 
 const DEFAULT_REDIRECT = "/";
 
-export const STYTCH_URL_BASE =
-  process.env.NODE_ENV === "production"
-    ? "https://api.stytch.com/v1/magic_links"
-    : "https://test.stytch.com/v1/magic_links";
+const STYTCH_SUBDOMAIN = process.env.NODE_ENV === "production" ? 'api' : 'test'
+export const STYTCH_BASE = `https://${STYTCH_SUBDOMAIN}.stytch.com/v1`
 
 // hours
 export const getClientOffset = (): number =>


### PR DESCRIPTION
i was seeing intermittent accidental logouts on my pixel. i'm pretty sure this is because the default Max-age/Expires is 'Session' (meaning it self implodes each and everytime Chrome restarts.

in the interest of extending their lifespan responsibly, this PR reaches out to stytch to validate the actual authentication token each time a user threatens to create a new reservation (unless they've already done it within the last 12 hours)