### PR TITLE
fix: ensure valid auth sessions are not discarded

### DIFF
--- a/app/routes/authenticate.tsx
+++ b/app/routes/authenticate.tsx
@@ -3,7 +3,7 @@ import { json } from "@remix-run/node";
 
 import { getUserByStytchId } from "~/models/user.server";
 import { createUserSession } from "~/session.server";
-import { STYTCH_BASE } from "~/utils";
+import { STYTCH_BASE, THIRTY_DAYS_IN_MIN } from "~/utils";
 
 export const meta: MetaFunction = () => [{ title: "Authenticate" }];
 
@@ -25,8 +25,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
         )}`,
       },
 
-      // 30 days (5 to 527040 is valid range)
-      body: JSON.stringify({ token, session_duration_minutes: 43200 }),
+      // valid range is 5 minutes to 527040 minutes
+      body: JSON.stringify({
+        token,
+        session_duration_minutes: THIRTY_DAYS_IN_MIN,
+      }),
     });
 
     const res = await raw.json();

--- a/app/routes/reservations.new.tsx
+++ b/app/routes/reservations.new.tsx
@@ -23,14 +23,12 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const lastValidated = await requireValidStytchToken(request);
   session.set("last_validated", lastValidated);
 
-  return json(
-    { userId },
-    {
-      headers: {
-        "Set-Cookie": await sessionStorage.commitSession(session),
-      },
-    },
-  );
+  const expires = new Date(lastValidated + 1000 * 60 * 43200);
+  expires;
+  // passing in expires should resolve the bug
+  const cookie = await sessionStorage.commitSession(session /*{ expires }*/);
+
+  return json({ userId }, { headers: { "Set-Cookie": cookie } });
 };
 
 export const action = async ({ request }: ActionFunctionArgs) => {

--- a/app/routes/reservations.new.tsx
+++ b/app/routes/reservations.new.tsx
@@ -13,7 +13,11 @@ import {
   requireValidStytchToken,
   sessionStorage,
 } from "~/session.server";
-import { anotherTimeFormattingFunc, getPacificOffset } from "~/utils";
+import {
+  anotherTimeFormattingFunc,
+  getPacificOffset,
+  THIRTY_DAYS_IN_MIN,
+} from "~/utils";
 
 // if an anonymous or stale user gets here, fail fast
 export const loader = async ({ request }: LoaderFunctionArgs) => {
@@ -23,10 +27,9 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const lastValidated = await requireValidStytchToken(request);
   session.set("last_validated", lastValidated);
 
-  const expires = new Date(lastValidated + 1000 * 60 * 43200);
-  expires;
-  // passing in expires should resolve the bug
-  const cookie = await sessionStorage.commitSession(session /*{ expires }*/);
+  // TODO: pass through genuine session expiration (instead of estimating)
+  const expires = new Date(lastValidated + 1000 * 60 * THIRTY_DAYS_IN_MIN);
+  const cookie = await sessionStorage.commitSession(session, { expires });
 
   return json({ userId }, { headers: { "Set-Cookie": cookie } });
 };

--- a/app/routes/reservations.new.tsx
+++ b/app/routes/reservations.new.tsx
@@ -27,8 +27,11 @@ export const loader = async ({ request }: LoaderFunctionArgs) => {
   const lastValidated = await requireValidStytchToken(request);
   session.set("last_validated", lastValidated);
 
-  // TODO: pass through genuine session expiration (instead of estimating)
+  // before we started setting the maxAge/expiration explicitly
+  // this codepath converted it to 'Session' which invalidates it
+  // everytime the browser itself restarts 🙃
   const expires = new Date(lastValidated + 1000 * 60 * THIRTY_DAYS_IN_MIN);
+  // TODO: pass through genuine session expiration (instead of estimating)
   const cookie = await sessionStorage.commitSession(session, { expires });
 
   return json({ userId }, { headers: { "Set-Cookie": cookie } });

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -68,7 +68,8 @@ export async function requireValidStytchToken(
   const session_token = session.get("stytch_session");
   const lastValidated = session.get('last_validated')
 
-  const stale = new Date().valueOf() - lastValidated > 1000 * 60 * 60 * 12
+  // we validate stytch tokens at most once a minute
+  const stale = new Date().valueOf() - lastValidated > 1000 * 60
   if (!stale) return lastValidated
 
   const rawResponse = await fetch(

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -3,7 +3,7 @@ import invariant from "tiny-invariant";
 
 import type { User } from "~/models/user.server";
 import { getUserById } from "~/models/user.server";
-import { STYTCH_BASE } from "~/utils";
+import { THIRTY_DAYS_IN_MIN, STYTCH_BASE } from "~/utils";
 
 invariant(process.env.SESSION_SECRET, "SESSION_SECRET must be set");
 
@@ -85,7 +85,7 @@ export async function requireValidStytchToken(
 
       body: JSON.stringify({
         session_token,
-        session_duration_minutes: 43200
+        session_duration_minutes: THIRTY_DAYS_IN_MIN
       }),
     },
   );

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -11,6 +11,8 @@ export type CourtType = "pb" | "bball" | "10s";
 
 const DEFAULT_REDIRECT = "/";
 
+export const THIRTY_DAYS_IN_MIN = 43200;
+
 const STYTCH_SUBDOMAIN = process.env.NODE_ENV === "production" ? 'api' : 'test'
 export const STYTCH_BASE = `https://${STYTCH_SUBDOMAIN}.stytch.com/v1`
 

--- a/cypress/support/create-user.ts
+++ b/cypress/support/create-user.ts
@@ -28,6 +28,7 @@ async function createAndLogin(email: string) {
     userId: user.id,
     remember: false,
     redirectTo: "/",
+    lastValidated: new Date().valueOf(),
   });
 
   const cookieValue = response.headers.get("Set-Cookie");

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "@terraformer/spatial": "^2.1.2",
         "classnames": "^2.5.1",
         "date-fns": "^4.1.0",
-        "date-fns-tz": "^3.1.3",
         "isbot": "^3.7.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -5095,9 +5094,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001594",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001594.tgz",
-      "integrity": "sha512-VblSX6nYqyJVs8DKFMldE2IVCJjZ225LW00ydtUWwh5hk9IfkTOffO6r8gJNsH0qqqeAF8KrbMYA2VEwTlGW5g==",
+      "version": "1.0.30001715",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001715.tgz",
+      "integrity": "sha512-7ptkFGMm2OAOgvZpwgA4yjQ5SQbrNVGdRjzH0pBdy1Fasvcr+KAeECmbCAECzTuDuoX0FCY8KzUxjf9+9kfZEw==",
       "dev": true,
       "funding": [
         {
@@ -5840,14 +5839,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
-      }
-    },
-    "node_modules/date-fns-tz": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.1.3.tgz",
-      "integrity": "sha512-ZfbMu+nbzW0mEzC8VZrLiSWvUIaI3aRHeq33mTe7Y38UctKukgqPR4nTDwcwS4d64Gf8GghnVsroBuMY3eiTeA==",
-      "peerDependencies": {
-        "date-fns": "^3.0.0"
       }
     },
     "node_modules/dayjs": {


### PR DESCRIPTION
this change ensures we set the maxAge/expiration explicitly when updating the cookie after asking stytch to verify the active session.

without this change, the value was changing from a genuine timestamp to 'Session', which self-implodes each and every time the browser restarts.

for awhile i thought the issue was specific to mobile chrome, but it was really that no one else that i asked to test was hitting the new reservation route and actually triggering revalidation. whoops!